### PR TITLE
Support and add command options : `--show-arg`, `--retry`, `--help`, `--score`, `--bench` and `--show-index`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,22 @@ the following command will perform 100 tests with a stack of 100 integers, then 
 bash push_swap_tester/tester.sh ../push_swap 100-102 100
 ```
 
+## Commands
+
+```
+USAGE
+./push_swap_tester.sh [directory-to-push_swap] [stacksize 0R range] [nb_of_test] {options}
+
+OPTIONS
+  --show-arg    Display arguments after the number of instructions.
+  --quiet       Don't display arguments if the tester catch an error.
+  --retry       Retry with same arguments during the last run or the specified run with --retry=[NUM].
+  --score       Show the score of the current entries, useful to compare output of two differents push_swap algo.
+  --bench       Use with --score, save the score in push_swap_benchmark.log, if is a new record or a new entries.
+                Use --rewrite-bench to erase saved score by the current score.
+  --show-index  Display sorted index of each arguments, the index is the offset position when the list is sorted.
+  --help/-h     Show this message.
+```
+
 ## Contribution
 If you noticed something wrong with the code or if you'd like to see a new feature, you can submit an issue. If you'd like to contribute please submit a pull request :) 

--- a/tester.sh
+++ b/tester.sh
@@ -7,6 +7,12 @@
 # Example 2: ./push_swap_tester.sh ../push_swap/ 3-5 50
 # Will test your program 50 times with a stack of 3 random ints, then 50 times with 4 ints , then 50 times with 5 ints.
 
+function _in {
+	local e match="$1"
+	shift
+	for e; do [[ "$e" == "$match" ]] && return 0; done
+	return 1
+}
 NOCOLOR='\033[0m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,11 +31,12 @@ LIGHTCYAN='\033[1;36m'
 WHITE='\033[1;37m'
 
 if [[ $# -ne 3 ]]; then
-    printf "Usage: ./push_swap_tester.sh [directory-to-push_swap] [stacksize 0R range] [nb_of_test]\n" >&2
-    exit -1
+	printf "Usage: ./push_swap_tester.sh [directory-to-push_swap] [stacksize 0R range] [nb_of_test]\n" >&2
+	printf "Options:\n" >&2
+	printf "  --show-arg:\tDisplay arguments after the number of instructions.\n" >&2
 fi
 
-rm -f push_swap_result.txt
+rm -f push_swap_result.log
 
 digit='^[0-9]+$' 		#digit number
 range='^[0-9]+-[0-9]+$' #range type 
@@ -84,14 +91,14 @@ for ((stack_size = $startRange; stack_size <= $endRange; stack_size++)); do
   for ((testNB = 0; testNB < $TotalNbTest; testNB++)); do
   	printf "${DARKGRAY} TEST $testNB: ${NOCOLOR}"
 	ARG=`./genstack.pl $stack_size -1000 1000` ;
-	"./$1/push_swap" $ARG > push_swap_result.txt ;
-	RESULT_CHECKER=`"./$1/checker" $ARG < push_swap_result.txt`
+	"./$1/push_swap" $ARG > push_swap_result.log; exitCode=$?
+	RESULT_CHECKER=`"./$1/checker" $ARG < push_swap_result.log`
 	if [[ "$RESULT_CHECKER" = "KO" ]]; then
 		printf "${RED}$RESULT_CHECKER ${NOCOLOR}"
 	else
 		printf "${GREEN}$RESULT_CHECKER ${NOCOLOR}"
 	fi
-	MOVES=` cat push_swap_result.txt | wc -l`
+	MOVES=` cat push_swap_result.log | wc -l`
 	if (( $stack_size <= 3 )) ; then
 		if (( $MOVES < 3 )); then
 			COLOR=${WHITE}
@@ -134,10 +141,14 @@ for ((stack_size = $startRange; stack_size <= $endRange; stack_size++)); do
 		fi
 	fi
 	printf "${COLOR} $MOVES ${NOCOLOR} instructions\n"
+	if [[ "$RESULT_CHECKER" = "KO" || "$COLOR" = "$RED" \
+		|| $exitCode != 0 ]] || $(_in "--show-arg" $@); then
+		printf "\t arguments was: ${CYAN}$ARG${NOCOLOR}\n"
+	fi
 	TOTAL=$(( $TOTAL + $MOVES ))
   done
   MEAN=$(( $TOTAL / $TotalNbTest ))
   printf "\nMean: $MEAN for stack of size $stack_size \n\n"
 done 
 
-rm -rf push_swap_result.txt
+rm -rf push_swap_result.log

--- a/tester.sh
+++ b/tester.sh
@@ -271,9 +271,9 @@ for ((stack_size = $startRange; stack_size <= $endRange; stack_size++)); do
 	if (! $(_in "--quiet" $@) && [[ "$RESULT_CHECKER" = "KO" || "$COLOR" = "$RED" \
 		|| $exitCode != 0 ]]) || $(_in "--show-arg" $@); then
 		printf "\t arguments was: ${CYAN}$ARG${NOCOLOR}\n"
-		if $(_in "--show-index" $@); then
-			printf "\t args index is: ${CYAN}$INDEXES${NOCOLOR}\n"
-		fi
+	fi
+	if $(_in "--show-index" $@); then
+		printf "\t args index is: ${CYAN}$INDEXES${NOCOLOR}\n"
 	fi
 	TOTAL=$(( $TOTAL + $MOVES ))
   done

--- a/tester.sh
+++ b/tester.sh
@@ -59,6 +59,7 @@ if [[ $# -lt 3 ]] && ! ( [[ $# -ge 2 ]] && $(_inv "--retry" $@) ) \
 	printf "\n" >&2
 	printf "${WHITE}OPTIONS\n${NOCOLOR}" >&2
 	printf "  ${WHITE}--show-arg${NOCOLOR}    Display arguments after the number of instructions.\n" >&2
+	printf "  ${WHITE}--quiet${NOCOLOR}       Don't display arguments if the tester catch an error.\n" >&2
 	printf "  ${WHITE}--retry${NOCOLOR}       Retry with same arguments during the last run or the specified run with ${WHITE}--retry=[NUM]${NOCOLOR}.\n" >&2
 	printf "  ${WHITE}--score${NOCOLOR}       Show the score of the current entries, useful to compare output of two differents push_swap algo.\n" >&2
 	printf "  ${WHITE}--bench${NOCOLOR}       Use with --score: Save the score in push_swap_benchmark.log, if is a new record or a new entries.\n" >&2
@@ -266,8 +267,8 @@ for ((stack_size = $startRange; stack_size <= $endRange; stack_size++)); do
 		fi
 	fi
 	printf "\n"
-	if [[ "$RESULT_CHECKER" = "KO" || "$COLOR" = "$RED" \
-		|| $exitCode != 0 ]] || $(_in "--show-arg" $@); then
+	if (! $(_in "--quiet" $@) && [[ "$RESULT_CHECKER" = "KO" || "$COLOR" = "$RED" \
+		|| $exitCode != 0 ]]) || $(_in "--show-arg" $@); then
 		printf "\t arguments was: ${CYAN}$ARG${NOCOLOR}\n"
 		if $(_in "--show-index" $@); then
 			printf "\t args index is: ${CYAN}$INDEXES${NOCOLOR}\n"

--- a/tester.sh
+++ b/tester.sh
@@ -52,11 +52,15 @@ LIGHTPURPLE='\033[1;35m'
 LIGHTCYAN='\033[1;36m'
 WHITE='\033[1;37m'
 
-if [[ $# -lt 3 ]] && ! ( [[ $# -ge 2 ]] && $(_inv "--retry" $@)); then
-	printf "Usage: ./push_swap_tester.sh [directory-to-push_swap] [stacksize 0R range] [nb_of_test] {options}\n" >&2
-	printf "Options:\n" >&2
-	printf "  --show-arg:\tDisplay arguments after the number of instructions.\n" >&2
-	printf "  --retry:\t\tRetry with same arguments during the last run or the specified run with --retry=[NUM].\n" >&2
+if [[ $# -lt 3 ]] && ! ( [[ $# -ge 2 ]] && $(_inv "--retry" $@) ) \
+	|| $(_inv "--help" $@) || $(_inv "-h" $@); then
+	printf "${WHITE}USAGE\n${NOCOLOR}" >&2
+	printf "./push_swap_tester.sh ${WHITE}[directory-to-push_swap] [stacksize 0R range] [nb_of_test] {options}\n${NOCOLOR}" >&2
+	printf "\n" >&2
+	printf "${WHITE}OPTIONS\n${NOCOLOR}" >&2
+	printf "  ${WHITE}--show-arg${NOCOLOR}\tDisplay arguments after the number of instructions.\n" >&2
+	printf "  ${WHITE}--retry${NOCOLOR}\t\tRetry with same arguments during the last run or the specified run with ${WHITE}--retry=[NUM]${NOCOLOR}.\n" >&2
+	printf "  ${WHITE}--help/-h${NOCOLOR}\t\tShow this message.\n" >&2
 	exit -1
 fi
 

--- a/tester.sh
+++ b/tester.sh
@@ -58,12 +58,12 @@ if [[ $# -lt 3 ]] && ! ( [[ $# -ge 2 ]] && $(_inv "--retry" $@) ) \
 	printf "./push_swap_tester.sh ${WHITE}[directory-to-push_swap] [stacksize 0R range] [nb_of_test] {options}\n${NOCOLOR}" >&2
 	printf "\n" >&2
 	printf "${WHITE}OPTIONS\n${NOCOLOR}" >&2
-	printf "  ${WHITE}--show-arg${NOCOLOR}\tDisplay arguments after the number of instructions.\n" >&2
-	printf "  ${WHITE}--retry${NOCOLOR}\t\tRetry with same arguments during the last run or the specified run with ${WHITE}--retry=[NUM]${NOCOLOR}.\n" >&2
-	printf "  ${WHITE}--score${NOCOLOR}\tShow the score of the current entries, useful to compare output of two differents push_swap algo.\n" >&2
-	printf "  ${WHITE}--bench${NOCOLOR}\tUse with --score: Save the score in push_swap_benchmark.log, if is a new record or a new entries.\n" >&2
-	printf "  ${WHITE}--show-index${NOCOLOR}\tDisplay sorted index of each arguments, the index is the offset position when the list is sorted.\n" >&2
-	printf "  ${WHITE}--help/-h${NOCOLOR}\t\tShow this message.\n" >&2
+	printf "  ${WHITE}--show-arg${NOCOLOR}    Display arguments after the number of instructions.\n" >&2
+	printf "  ${WHITE}--retry${NOCOLOR}       Retry with same arguments during the last run or the specified run with ${WHITE}--retry=[NUM]${NOCOLOR}.\n" >&2
+	printf "  ${WHITE}--score${NOCOLOR}       Show the score of the current entries, useful to compare output of two differents push_swap algo.\n" >&2
+	printf "  ${WHITE}--bench${NOCOLOR}       Use with --score: Save the score in push_swap_benchmark.log, if is a new record or a new entries.\n" >&2
+	printf "  ${WHITE}--show-index${NOCOLOR}  Display sorted index of each arguments, the index is the offset position when the list is sorted.\n" >&2
+	printf "  ${WHITE}--help/-h${NOCOLOR}     Show this message.\n" >&2
 	exit -1
 fi
 

--- a/tester.sh
+++ b/tester.sh
@@ -62,7 +62,8 @@ if [[ $# -lt 3 ]] && ! ( [[ $# -ge 2 ]] && $(_inv "--retry" $@) ) \
 	printf "  ${WHITE}--quiet${NOCOLOR}       Don't display arguments if the tester catch an error.\n" >&2
 	printf "  ${WHITE}--retry${NOCOLOR}       Retry with same arguments during the last run or the specified run with ${WHITE}--retry=[NUM]${NOCOLOR}.\n" >&2
 	printf "  ${WHITE}--score${NOCOLOR}       Show the score of the current entries, useful to compare output of two differents push_swap algo.\n" >&2
-	printf "  ${WHITE}--bench${NOCOLOR}       Use with --score: Save the score in push_swap_benchmark.log, if is a new record or a new entries.\n" >&2
+	printf "  ${WHITE}--bench${NOCOLOR}       Use with --score, save the score in push_swap_benchmark.log, if is a new record or a new entries.\n" >&2
+	printf "  ${WHITE}       ${NOCOLOR}       Use --rewrite-bench to erase saved score by the current score.\n" >&2
 	printf "  ${WHITE}--show-index${NOCOLOR}  Display sorted index of each arguments, the index is the offset position when the list is sorted.\n" >&2
 	printf "  ${WHITE}--help/-h${NOCOLOR}     Show this message.\n" >&2
 	exit -1
@@ -241,7 +242,7 @@ for ((stack_size = $startRange; stack_size <= $endRange; stack_size++)); do
 					DURING="$(echo $P2 | awk '{print $2}')"
 				if [[ $MOVES -eq $RECORD ]]; then
 					printf "\t${WHITE}(BEST)${NOCOLOR}"
-				elif [[ $MOVES -lt $RECORD ]]; then
+				elif [[ $MOVES -lt $RECORD ]] || $(_in "--rewrite-bench" $@); then
 					delta=$(($MOVES - $RECORD))
 					printf "\t${WHITE}(${GREEN}$delta${WHITE} NEW RECORD"
 					printf " was ${LIGHTBLUE}$RECORD${WHITE} in $DURING)${NOCOLOR}"


### PR DESCRIPTION
I improve this tester to be more convenient when we use for debug purpose, with `--retry` we can retry the last run with the same arguments.

I added a benchmarked system to store the lowest iteration number to compare between to build of push_swap. The score is only saved when we use `--bench` to allow *readonly mode*.

# My Changes : 
 - I added the following command options: `--show-arg`, `--retry`, `--help`, `--score`, `--bench` and `--show-index`.

```
USAGE
./push_swap_tester.sh [directory-to-push_swap] [stacksize 0R range] [nb_of_test] {options}

OPTIONS
  --show-arg	Display arguments after the number of instructions.
  --retry	Retry with same arguments during the last run or the specified run with --retry=[NUM].
  --score	Show the score of the current entries, useful to compare output of two differents push_swap algo.
  --bench	Use with --score: Save the score in push_swap_benchmark.log, if is a new record or a new entries.
  --show-index	Display sorted index of each arguments, the index is the offset position when the list is sorted.
  --help/-h	Show this message.
```

 - If we got a KO or an error, we displayed the arguments (can be `--quiet`).
 - I used `.log` extension instead of `.txt` (the rules *.log in .gitignore is more convenient).